### PR TITLE
13 req rep server to provide data services

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ from ether import ether
 def _get_config_path(config_name: str) -> str:
     return os.path.join(os.path.dirname(__file__), "config", f"{config_name}.yaml")
 
-# Initialize with config
+# Tap in to the ether with config
 config_path = _get_config_path("dual_processors")
-ether.init(config=config_path)
+ether.tap(config=config_path)
 
 # Start the distributed system
 ether.start()

--- a/src/ether/__init__.py
+++ b/src/ether/__init__.py
@@ -7,7 +7,7 @@ import time
 import uuid
 
 from .decorators import ether_pub, ether_sub, ether_init, ether_save, ether_cleanup, ether_start, ether_get, ether_save_all, ether_shutdown
-from .utils import _get_logger
+from .utils import get_ether_logger
 from ._internal._ether import _ether
 from ._internal._config import EtherConfig
 

--- a/src/ether/__init__.py
+++ b/src/ether/__init__.py
@@ -43,7 +43,7 @@ class Ether:
             cls._instance = super(Ether, cls).__new__(cls)
         return cls._instance
 
-    def init(self, config: Optional[Union[str, dict, EtherConfig]] = None, restart: bool = False):
+    def tap(self, config: Optional[Union[str, dict, EtherConfig]] = None, restart: bool = False):
         """Initialize the Ether messaging system."""
         # Only set root logger level without adding a handler
         logging.getLogger().setLevel(logging.DEBUG)

--- a/src/ether/__init__.py
+++ b/src/ether/__init__.py
@@ -40,7 +40,9 @@ def _request(service_class: str, method_name: str, params=None, request_type="ge
 class Ether:
     pub = staticmethod(_pub)
     request = staticmethod(_request)
-    save = staticmethod(functools.partial(_pub, {}, topic="Ether.save"))
+    get = staticmethod(functools.partial(_request, request_type="get"))
+    save = staticmethod(functools.partial(_request, request_type="save"))
+    save_all = staticmethod(functools.partial(_pub, {}, topic="Ether.save_all"))
     start = staticmethod(functools.partial(_pub, {}, topic="Ether.start"))
     cleanup = staticmethod(functools.partial(_pub, {}, topic="Ether.cleanup"))
     shutdown = staticmethod(functools.partial(_pub, {}, topic="Ether.shutdown"))
@@ -77,7 +79,7 @@ class Ether:
 
     def shutdown(self):
         self.cleanup()
-        self.save()
+        self.save_all()
         _ether.shutdown()
  
 

--- a/src/ether/__init__.py
+++ b/src/ether/__init__.py
@@ -75,7 +75,7 @@ class Ether:
             # Register single cleanup handler
             atexit.register(self.shutdown)
 
-        time.sleep(0.002)
+        time.sleep(1.1)
 
     def shutdown(self):
         self.cleanup()

--- a/src/ether/__init__.py
+++ b/src/ether/__init__.py
@@ -6,7 +6,7 @@ import atexit
 import time
 import uuid
 
-from .decorators import ether_pub, ether_sub, ether_init, ether_save, ether_cleanup, ether_start
+from .decorators import ether_pub, ether_sub, ether_init, ether_save, ether_cleanup, ether_start, ether_get, ether_save_all, ether_shutdown
 from .utils import _get_logger
 from ._internal._ether import _ether
 from ._internal._config import EtherConfig
@@ -87,6 +87,6 @@ class Ether:
 # instantiate singleton for API
 ether = Ether()
 # export decorators
-decorators = ['ether_pub', 'ether_sub', 'ether_init', 'ether_save', 'ether_cleanup', 'ether_start']
+decorators = ['ether_pub', 'ether_sub', 'ether_init', 'ether_save', 'ether_cleanup', 'ether_start', 'ether_get', 'ether_save_all', 'ether_shutdown']
 __all__ = ['ether'] + decorators
 

--- a/src/ether/_internal/_ether.py
+++ b/src/ether/_internal/_ether.py
@@ -95,6 +95,7 @@ class _Ether:
     _logger = None
     _redis_port = None
     _redis_pidfile = None
+    _redis_process = None
     _pubsub_process = None
     _monitor_process = None
     _instance_manager = None

--- a/src/ether/_internal/_ether.py
+++ b/src/ether/_internal/_ether.py
@@ -532,7 +532,7 @@ class _Ether:
 
     def request(self, service_class: str, method_name: str, params=None, request_type="get", timeout=2500):
         """Make a request to a service"""
-        self._logger.debug(f"Request received - Service: {service_class}.{method_name}")
+        self._logger.debug(f"Request received - Service: {service_class}.{method_name}.{request_type}")
         
         if not self._started:
             self._logger.debug("Cannot make request: Ether system not started")
@@ -567,6 +567,7 @@ class _Ether:
             while retries > 0:
                 try:
                     msg = self._request_socket.recv_multipart()
+                    self._logger.debug(f"Reply received: {msg}")
                     break
                 except Exception as e:
                     self._logger.error(f"Error receiving reply: {e}, retries remaining: {retries}")

--- a/src/ether/_internal/_ether.py
+++ b/src/ether/_internal/_ether.py
@@ -13,7 +13,7 @@ import json
 import signal
 import multiprocessing
 
-from ..utils import _ETHER_PUB_PORT, _get_logger
+from ..utils import _ETHER_PUB_PORT, get_ether_logger
 from ._session import EtherSession, session_process_launcher
 from ._pubsub import _EtherPubSubProxy
 from ..liaison import EtherInstanceLiaison 
@@ -50,7 +50,7 @@ def _run_pubsub():
 
 def _run_monitor():
     """Standalone function to run instance monitoring"""
-    logger = _get_logger("EtherMonitor")
+    logger = get_ether_logger("EtherMonitor")
     liaison = EtherInstanceLiaison()
     
     while True:
@@ -110,7 +110,7 @@ class _Ether:
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(_Ether, cls).__new__(cls)
-            cls._instance._logger = _get_logger("Ether")
+            cls._instance._logger = get_ether_logger("Ether")
             cls._instance._logger.debug("Creating new Ether instance")
 
             cls._instance._logger.debug("Initializing Ether instance")

--- a/src/ether/_internal/_manager.py
+++ b/src/ether/_internal/_manager.py
@@ -1,7 +1,7 @@
 from typing import Union
 from multiprocessing import Process
 
-from ..utils import _get_logger
+from ..utils import get_ether_logger
 from ._config import EtherConfig
 from ether.liaison import EtherInstanceLiaison
 
@@ -14,7 +14,7 @@ class _EtherInstanceManager:
             autolaunch: bool = True
         ):
         self._instance_processes: dict[str, Process] = {}
-        self._logger = _get_logger("EtherInstanceManager")
+        self._logger = get_ether_logger("EtherInstanceManager")
         self._logger.debug("Initializing EtherInstanceManager")
         self._liaison = EtherInstanceLiaison()
         self._config = config

--- a/src/ether/_internal/_pubsub.py
+++ b/src/ether/_internal/_pubsub.py
@@ -1,7 +1,7 @@
 import zmq
 import uuid
 
-from ..utils import _ETHER_SUB_PORT, _ETHER_PUB_PORT, _get_logger
+from ..utils import _ETHER_SUB_PORT, _ETHER_PUB_PORT, get_ether_logger
 
 class _EtherPubSubProxy:
     """Proxy that uses XPUB/XSUB sockets for efficient message distribution.
@@ -12,7 +12,7 @@ class _EtherPubSubProxy:
     def __init__(self):
         self.id = uuid.uuid4()
         self.name = f"EtherPubSubProxy_{self.id}"
-        self._logger = _get_logger("EtherPubSubProxy")
+        self._logger = get_ether_logger("EtherPubSubProxy")
         self._logger.debug("Initializing PubSub proxy")
         
         self.capture_socket = None

--- a/src/ether/_internal/_registry.py
+++ b/src/ether/_internal/_registry.py
@@ -10,7 +10,7 @@ import json
 import sys
 import importlib
 
-from ..utils import _get_logger, _ETHER_SUB_PORT, _ETHER_PUB_PORT
+from ..utils import get_ether_logger, _ETHER_SUB_PORT, _ETHER_PUB_PORT
 from ether.liaison import EtherInstanceLiaison
 from ._config import EtherClassConfig
 from ._reqrep import (
@@ -30,7 +30,7 @@ class EtherRegistry:
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(EtherRegistry, cls).__new__(cls)
-            cls._instance._logger = _get_logger("EtherRegistry")  # Will use default levels
+            cls._instance._logger = get_ether_logger("EtherRegistry")  # Will use default levels
         return cls._instance
     
     def mark_for_processing(self, class_qualname: str, module_name: str):
@@ -119,7 +119,7 @@ class EtherRegistry:
 def add_ether_functionality(cls):
     """Adds Ether functionality directly to a class"""
     # Use the class name for logging
-    logger = _get_logger(cls.__name__)  # Will use default levels
+    logger = get_ether_logger(cls.__name__)  # Will use default levels
     logger.debug(f"Adding Ether functionality to class: {cls.__name__}")
     
     # Check if already processed
@@ -144,7 +144,7 @@ def add_ether_functionality(cls):
         self.id = str(uuid.uuid4())
         self.name = name or self.id
         # Pass log_level as both console and file level if specified
-        self._logger = _get_logger(
+        self._logger = get_ether_logger(
             process_name=self.__class__.__name__,
             instance_name=self.name,
             # console_level=log_level,

--- a/src/ether/_internal/_reqrep.py
+++ b/src/ether/_internal/_reqrep.py
@@ -1,44 +1,54 @@
 import zmq
-import uuid
-import json
-from typing import Dict, Optional
 import time
-
+import uuid
+from typing import Dict, Optional
 from ..utils import _get_logger
 
-# Constants for MDP protocol
-WORKER_READY = b"\x01"  # Worker tells broker it's ready
-REQUEST = b"\x02"       # Client request to broker
-REPLY = b"\x03"        # Worker reply to broker
+# MDP protocol constants
+MDPW_WORKER = b"MDPW01"  # MDP/Worker v0.1
+MDPC_CLIENT = b"MDPC01"  # MDP/Client v0.1
+
+# MDP command constants
+W_READY = b"\x01"      # Worker ready
+W_REQUEST = b"\x02"    # Worker request
+W_REPLY = b"\x03"      # Worker reply
+W_HEARTBEAT = b"\x04"  # Worker heartbeat
+W_DISCONNECT = b"\x05" # Worker disconnect
 
 class Service:
     """Represents a service and its associated workers"""
     def __init__(self, name: str):
         self.name = name
-        self.workers: Dict[str, 'Worker'] = {}  # worker_id -> Worker
-        self.requests = []  # List of pending requests
-        
+        self.waiting = []  # Available workers for this service
+        self.requests = [] # Pending requests for this service
+
 class Worker:
     """Represents a worker instance"""
     def __init__(self, id: str, service: str, address: bytes):
         self.id = id
-        self.service = service
+        self.service = service  # Service this worker provides
         self.address = address
         self.expiry = time.time() + 5  # 5 second timeout
+        self.liveness = 3    # 3 heartbeats missed before death
 
 class EtherReqRepBroker:
-    """Broker implementing Majordomo pattern for request-reply messaging"""
+    """Broker implementing Majordomo Protocol v0.1"""
+    
+    HEARTBEAT_INTERVAL = 2500  # msecs
+    HEARTBEAT_LIVENESS = 3    # 3-5 is reasonable
+
     def __init__(self, frontend_port: int = 5559, backend_port: int = 5560):
         self.id = str(uuid.uuid4())
         self._logger = _get_logger("EtherReqRepBroker")
-        self._logger.debug("Initializing ReqRep broker")
+        self._logger.debug("Initializing MDP broker")
         
         self.frontend_port = frontend_port
         self.backend_port = backend_port
         self.services: Dict[str, Service] = {}  # service_name -> Service
         self.workers: Dict[str, Worker] = {}    # worker_id -> Worker
+        self.heartbeat_at = time.time() + 0.001 * self.HEARTBEAT_INTERVAL
         self._setup_sockets()
-        
+
     def _setup_sockets(self):
         """Setup ROUTER sockets for both frontend and backend"""
         self._logger.debug("Setting up sockets")
@@ -55,110 +65,151 @@ class EtherReqRepBroker:
         self.poller = zmq.Poller()
         self.poller.register(self.frontend, zmq.POLLIN)
         self.poller.register(self.backend, zmq.POLLIN)
-        
+
     def _process_client(self, sender: bytes, empty: bytes, msg: list):
-        """Process a client request"""
+        """Process a client request using MDP"""
         assert empty == b''
-        service_name = msg[0].decode()
-        request = msg[1]
+        assert msg.pop(0) == MDPC_CLIENT  # Protocol header
+        service_name = msg.pop(0).decode()
+        request = msg  # Remaining frames are request
         
         service = self.services.get(service_name)
         if not service:
-            service = Service(service_name)
-            self.services[service_name] = service
+            self._logger.warning(f"Service {service_name} not found")
+            return
             
         # Queue the request
         service.requests.append((sender, request))
-        self._logger.debug(f"Client request for service: {service_name}")
+        self._logger.debug(f"Client request queued for service: {service_name}")
         self._dispatch_requests(service)
-        
+
     def _process_worker(self, sender: bytes, empty: bytes, msg: list):
-        """Process a worker message"""
+        """Process worker message using MDP"""
         assert empty == b''
-        command = msg[0]
-        service_name = msg[1].decode()
+        assert msg.pop(0) == MDPW_WORKER  # Protocol header
         
+        command = msg.pop(0)
         worker_id = sender.hex()
-        service = self.services.get(service_name)
+        service_name = msg.pop(0).decode()
         
-        if command == WORKER_READY:
-            # New worker registration
-            if not service:
-                service = Service(service_name)
-                self.services[service_name] = service
-                
+        # Get or create the service
+        service = self.services.get(service_name)
+        if service is None and command == W_READY:
+            # Only create service on worker registration
+            service = Service(service_name)
+            self.services[service_name] = service
+            self._logger.debug(f"Created new service: {service_name}")
+
+        if not service:
+            self._logger.warning(f"Service {service_name} not found")
+            return
+
+        if command == W_READY:
+            # Worker registering for first time
             worker = Worker(worker_id, service_name, sender)
             self.workers[worker_id] = worker
-            service.workers[worker_id] = worker
+            service.waiting.append(worker)
             self._logger.debug(f"Worker registered for service: {service_name}")
-            
-        elif command == REPLY:
-            # Worker reply to previous request
+
+        elif command == W_REPLY:
             if worker_id in self.workers:
-                reply = msg[2]
-                client = msg[3]  # Original client address
-                self.frontend.send_multipart([client, b'', reply])
-                self._logger.debug(f"Worker reply sent to client for service: {service_name}")
-                self._dispatch_requests(service)  # Process any pending requests
+                worker = self.workers[worker_id]
+                client = msg.pop(0)  # Original client address
+                reply = msg  # Remaining frames are reply
                 
+                # Send reply to client with MDP envelope
+                self.frontend.send_multipart([
+                    client, 
+                    b'', 
+                    MDPC_CLIENT,
+                    service_name.encode(),
+                    *reply
+                ])
+                
+                # Worker is now available again
+                worker.expiry = time.time() + 5
+                service.waiting.append(worker)
+                self._dispatch_requests(service)
+
+        elif command == W_HEARTBEAT:
+            if worker_id in self.workers:
+                worker = self.workers[worker_id]
+                worker.expiry = time.time() + 5
+                worker.liveness = self.HEARTBEAT_LIVENESS
+
+        elif command == W_DISCONNECT:
+            self._delete_worker(worker_id)
+
+    def _delete_worker(self, worker_id: str):
+        """Delete worker from all data structures"""
+        if worker_id in self.workers:
+            worker = self.workers[worker_id]
+            service = self.services.get(worker.service)
+            if service:
+                if worker in service.waiting:
+                    service.waiting.remove(worker)
+            del self.workers[worker_id]
+
+    def _purge_workers(self):
+        """Look for and kill expired workers"""
+        now = time.time()
+        for worker_id, worker in list(self.workers.items()):
+            if now > worker.expiry:
+                self._logger.debug(f"Deleting expired worker: {worker_id}")
+                self._delete_worker(worker_id)
+
+    def _send_heartbeats(self):
+        """Send heartbeats to waiting workers if it's time"""
+        if time.time() > self.heartbeat_at:
+            for worker in self.workers.values():
+                self.backend.send_multipart([
+                    worker.address,
+                    b'',
+                    MDPW_WORKER,
+                    W_HEARTBEAT
+                ])
+            self.heartbeat_at = time.time() + 0.001 * self.HEARTBEAT_INTERVAL
+
     def _dispatch_requests(self, service: Service):
         """Attempt to dispatch pending requests to available workers"""
-        if not service.requests:
-            return
-            
-        # Find available workers
-        available_workers = [w for w in service.workers.values() 
-                           if time.time() < w.expiry]
-        
-        while service.requests and available_workers:
+        while service.requests and service.waiting:
             client, request = service.requests.pop(0)
-            worker = available_workers.pop(0)
+            worker = service.waiting.pop(0)
             
-            # Update worker expiry
-            worker.expiry = time.time() + 5
-            
-            # Forward request to worker
+            # Forward request to worker with MDP envelope
             self.backend.send_multipart([
                 worker.address,
                 b'',
-                REQUEST,
+                MDPW_WORKER,
+                W_REQUEST,
                 client,
-                request
+                *request
             ])
             self._logger.debug(f"Request dispatched to worker for service: {service.name}")
-            
+
     def run(self):
         """Main broker loop"""
         self._logger.info("Starting broker loop")
         try:
             while True:
-                events = dict(self.poller.poll(timeout=1000))
+                events = dict(self.poller.poll(self.HEARTBEAT_INTERVAL))
                 
-                # Process client requests
                 if self.frontend in events:
                     msg = self.frontend.recv_multipart()
                     self._process_client(msg[0], msg[1], msg[2:])
                     
-                # Process worker messages
                 if self.backend in events:
                     msg = self.backend.recv_multipart()
                     self._process_worker(msg[0], msg[1], msg[2:])
+                
+                self._purge_workers()
+                self._send_heartbeats()
                     
-                # Clean up expired workers
-                now = time.time()
-                for service in self.services.values():
-                    expired = [wid for wid, w in service.workers.items() 
-                             if w.expiry < now]
-                    for wid in expired:
-                        worker = service.workers.pop(wid)
-                        self.workers.pop(worker.id, None)
-                        self._logger.debug(f"Removed expired worker from service: {service.name}")
-                        
         except Exception as e:
             self._logger.error(f"Broker error: {e}")
         finally:
             self.cleanup()
-            
+
     def cleanup(self):
         """Clean up broker resources"""
         self._logger.debug("Cleaning up broker")

--- a/src/ether/_internal/_reqrep.py
+++ b/src/ether/_internal/_reqrep.py
@@ -2,7 +2,7 @@ import zmq
 import time
 import uuid
 from typing import Dict, Optional
-from ..utils import _get_logger
+from ..utils import get_ether_logger
 
 # MDP protocol constants
 MDPW_WORKER = b"MDPW01"  # MDP/Worker v0.1
@@ -51,7 +51,7 @@ class EtherReqRepBroker:
 
     def __init__(self, frontend_port: int = 5559, backend_port: int = 5560):
         self.id = str(uuid.uuid4())
-        self._logger = _get_logger("EtherReqRepBroker")
+        self._logger = get_ether_logger("EtherReqRepBroker")
         self._logger.debug("Initializing MDP broker")
         
         self.frontend_port = frontend_port

--- a/src/ether/_internal/_reqrep.py
+++ b/src/ether/_internal/_reqrep.py
@@ -1,0 +1,170 @@
+import zmq
+import uuid
+import json
+from typing import Dict, Optional
+import time
+
+from ..utils import _get_logger
+
+# Constants for MDP protocol
+WORKER_READY = b"\x01"  # Worker tells broker it's ready
+REQUEST = b"\x02"       # Client request to broker
+REPLY = b"\x03"        # Worker reply to broker
+
+class Service:
+    """Represents a service and its associated workers"""
+    def __init__(self, name: str):
+        self.name = name
+        self.workers: Dict[str, 'Worker'] = {}  # worker_id -> Worker
+        self.requests = []  # List of pending requests
+        
+class Worker:
+    """Represents a worker instance"""
+    def __init__(self, id: str, service: str, address: bytes):
+        self.id = id
+        self.service = service
+        self.address = address
+        self.expiry = time.time() + 5  # 5 second timeout
+
+class EtherReqRepBroker:
+    """Broker implementing Majordomo pattern for request-reply messaging"""
+    def __init__(self, frontend_port: int = 5559, backend_port: int = 5560):
+        self.id = str(uuid.uuid4())
+        self._logger = _get_logger("EtherReqRepBroker")
+        self._logger.debug("Initializing ReqRep broker")
+        
+        self.frontend_port = frontend_port
+        self.backend_port = backend_port
+        self.services: Dict[str, Service] = {}  # service_name -> Service
+        self.workers: Dict[str, Worker] = {}    # worker_id -> Worker
+        self._setup_sockets()
+        
+    def _setup_sockets(self):
+        """Setup ROUTER sockets for both frontend and backend"""
+        self._logger.debug("Setting up sockets")
+        self.context = zmq.Context()
+        
+        # Socket for clients
+        self.frontend = self.context.socket(zmq.ROUTER)
+        self.frontend.bind(f"tcp://*:{self.frontend_port}")
+        
+        # Socket for workers
+        self.backend = self.context.socket(zmq.ROUTER)
+        self.backend.bind(f"tcp://*:{self.backend_port}")
+        
+        self.poller = zmq.Poller()
+        self.poller.register(self.frontend, zmq.POLLIN)
+        self.poller.register(self.backend, zmq.POLLIN)
+        
+    def _process_client(self, sender: bytes, empty: bytes, msg: list):
+        """Process a client request"""
+        assert empty == b''
+        service_name = msg[0].decode()
+        request = msg[1]
+        
+        service = self.services.get(service_name)
+        if not service:
+            service = Service(service_name)
+            self.services[service_name] = service
+            
+        # Queue the request
+        service.requests.append((sender, request))
+        self._logger.debug(f"Client request for service: {service_name}")
+        self._dispatch_requests(service)
+        
+    def _process_worker(self, sender: bytes, empty: bytes, msg: list):
+        """Process a worker message"""
+        assert empty == b''
+        command = msg[0]
+        service_name = msg[1].decode()
+        
+        worker_id = sender.hex()
+        service = self.services.get(service_name)
+        
+        if command == WORKER_READY:
+            # New worker registration
+            if not service:
+                service = Service(service_name)
+                self.services[service_name] = service
+                
+            worker = Worker(worker_id, service_name, sender)
+            self.workers[worker_id] = worker
+            service.workers[worker_id] = worker
+            self._logger.debug(f"Worker registered for service: {service_name}")
+            
+        elif command == REPLY:
+            # Worker reply to previous request
+            if worker_id in self.workers:
+                reply = msg[2]
+                client = msg[3]  # Original client address
+                self.frontend.send_multipart([client, b'', reply])
+                self._logger.debug(f"Worker reply sent to client for service: {service_name}")
+                self._dispatch_requests(service)  # Process any pending requests
+                
+    def _dispatch_requests(self, service: Service):
+        """Attempt to dispatch pending requests to available workers"""
+        if not service.requests:
+            return
+            
+        # Find available workers
+        available_workers = [w for w in service.workers.values() 
+                           if time.time() < w.expiry]
+        
+        while service.requests and available_workers:
+            client, request = service.requests.pop(0)
+            worker = available_workers.pop(0)
+            
+            # Update worker expiry
+            worker.expiry = time.time() + 5
+            
+            # Forward request to worker
+            self.backend.send_multipart([
+                worker.address,
+                b'',
+                REQUEST,
+                client,
+                request
+            ])
+            self._logger.debug(f"Request dispatched to worker for service: {service.name}")
+            
+    def run(self):
+        """Main broker loop"""
+        self._logger.info("Starting broker loop")
+        try:
+            while True:
+                events = dict(self.poller.poll(timeout=1000))
+                
+                # Process client requests
+                if self.frontend in events:
+                    msg = self.frontend.recv_multipart()
+                    self._process_client(msg[0], msg[1], msg[2:])
+                    
+                # Process worker messages
+                if self.backend in events:
+                    msg = self.backend.recv_multipart()
+                    self._process_worker(msg[0], msg[1], msg[2:])
+                    
+                # Clean up expired workers
+                now = time.time()
+                for service in self.services.values():
+                    expired = [wid for wid, w in service.workers.items() 
+                             if w.expiry < now]
+                    for wid in expired:
+                        worker = service.workers.pop(wid)
+                        self.workers.pop(worker.id, None)
+                        self._logger.debug(f"Removed expired worker from service: {service.name}")
+                        
+        except Exception as e:
+            self._logger.error(f"Broker error: {e}")
+        finally:
+            self.cleanup()
+            
+    def cleanup(self):
+        """Clean up broker resources"""
+        self._logger.debug("Cleaning up broker")
+        if hasattr(self, 'frontend'):
+            self.frontend.close()
+        if hasattr(self, 'backend'):
+            self.backend.close()
+        if hasattr(self, 'context'):
+            self.context.term() 

--- a/src/ether/_internal/_session.py
+++ b/src/ether/_internal/_session.py
@@ -9,7 +9,7 @@ import multiprocessing
 import errno
 from time import sleep
 
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 
 class EtherSession: 
     DISCOVERY_PUB_PORT = 301309
@@ -21,7 +21,7 @@ class EtherSession:
         self.context = zmq.Context()
         self.is_discovery_service = False
         self.running = False
-        self._logger = _get_logger(process_name="EtherSession")
+        self._logger = get_ether_logger(process_name="EtherSession")
         
         self.metadata = {
             "session_id": self.session_id,

--- a/src/ether/decorators.py
+++ b/src/ether/decorators.py
@@ -1,12 +1,15 @@
 import functools
-from ._internal._registry import _ether_pub, _ether_sub
+from ._internal._registry import _ether_pub, _ether_sub, _ether_save, _ether_get
 
 # main pub/sub decorators
 ether_pub = _ether_pub
 ether_sub = _ether_sub
+ether_save = _ether_save
+ether_get = _ether_get
 
 # partials for subscribing to ether-lifecycle topics
 ether_init = functools.partial(ether_sub, topic="Ether.init")
-ether_save = functools.partial(ether_sub, topic="Ether.save")
+ether_save_all = functools.partial(ether_sub, topic="Ether.save_all")
 ether_start = functools.partial(ether_sub, topic="Ether.start")
 ether_cleanup = functools.partial(ether_sub, topic="Ether.cleanup")
+ether_shutdown = functools.partial(ether_sub, topic="Ether.shutdown")

--- a/src/ether/liaison.py
+++ b/src/ether/liaison.py
@@ -4,7 +4,7 @@ import json
 import time
 import os
 
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 
 
 class EtherInstanceLiaison:
@@ -22,7 +22,7 @@ class EtherInstanceLiaison:
         self.redis = redis.Redis.from_url(redis_url, decode_responses=True)
         self.instance_key_prefix = "ether:instance:"
         self._ttl = 60  # seconds until instance considered dead
-        self._logger = _get_logger("EtherInstanceLiaison")
+        self._logger = get_ether_logger("EtherInstanceLiaison")
     
     def __init__(self, redis_url: str = "redis://localhost:6379"):
         # __new__ handles initialization

--- a/src/ether/utils.py
+++ b/src/ether/utils.py
@@ -35,7 +35,7 @@ def get_ether_logger(
     
     # Create formatters with timestamps
     formatter = logging.Formatter(
-        '%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s',
+        '%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(filename)s:%(funcName)s:%(lineno)d - %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S'
     )
     

--- a/src/ether/utils.py
+++ b/src/ether/utils.py
@@ -14,7 +14,7 @@ def _ensure_log_dir(path: Path):
     """Ensure log directory exists"""
     path.mkdir(parents=True, exist_ok=True)
 
-def _get_logger(
+def get_ether_logger(
     process_name: str, 
     run_id: str = None,
     instance_name: str = None, 

--- a/src/examples/external_class_integration/main.py
+++ b/src/examples/external_class_integration/main.py
@@ -33,10 +33,10 @@ def main(config_name):
     ether.tap(config=config_path)
 
     # Use the DataGenerator class directly
-    from examples.external_class_integration import DataGenerator
-    generator = DataGenerator(process_id=1)
-    generator.generate_data(data=42)
-    time.sleep(0.1)  # Give time for processing
+    # from examples.external_class_integration import DataGenerator
+    # generator = DataGenerator(process_id=1)
+    # generator.generate_data(data=42)
+    # time.sleep(0.1)  # Give time for processing
 
     # Use the pub function to trigger DataGenerator.generate_data
     # via the automatically launched instance

--- a/src/examples/external_class_integration/main.py
+++ b/src/examples/external_class_integration/main.py
@@ -30,7 +30,7 @@ def main(config_name):
     """
     # Initialize Ether with our configuration
     config_path = _get_config_path(config_name)
-    ether.init(config=config_path)
+    ether.tap(config=config_path)
 
     # Use the DataGenerator class directly
     from examples.external_class_integration import DataGenerator

--- a/src/examples/simple_data_processing/collector.py
+++ b/src/examples/simple_data_processing/collector.py
@@ -7,7 +7,7 @@ class DataCollector:
     max = None
     min = None
 
-    @ether_sub(topic="result")
+    @ether_sub
     @ether_pub(topic="summarize")
     def collect_result(self, result: int) -> None:
         self.results.append(result)

--- a/src/examples/simple_data_processing/generator.py
+++ b/src/examples/simple_data_processing/generator.py
@@ -4,7 +4,7 @@ from ether import ether_pub, ether_sub, ether_start
 class DataGenerator:
     
     @ether_start()
-    @ether_pub(topic="data")
+    @ether_pub(topic="DataProcessor.process_data")
     def generate_data(self, data: int = 42) -> dict:
         print(f"DataGenerator[PID {os.getpid()}]: Generating data - {data}")
         return {"data": data}

--- a/src/examples/simple_data_processing/processor.py
+++ b/src/examples/simple_data_processing/processor.py
@@ -5,8 +5,8 @@ class DataProcessor:
     def __init__(self, multiplier: int = 2):
         self.multiplier = multiplier
     
-    @ether_sub(topic="data")
-    @ether_pub(topic="result")
+    @ether_sub
+    @ether_pub(topic="DataCollector.collect_result")
     def process_data(self, data: int = 0) -> dict:
         print(f"DataProcessor[PID {os.getpid()}]: Processing input data - {data}")
         result = data * self.multiplier

--- a/src/examples/simple_data_processing/run_dual_processors.py
+++ b/src/examples/simple_data_processing/run_dual_processors.py
@@ -58,7 +58,7 @@ def main(config_name):
     ether.start()
     time.sleep(1.002)
 
-    ether.shutdown()
+    # ether.shutdown()
 
     # you can still use your code normally when ether is not running
     # in other words, if your code is still used other places, it will still work

--- a/src/examples/simple_data_processing/run_dual_processors.py
+++ b/src/examples/simple_data_processing/run_dual_processors.py
@@ -51,7 +51,7 @@ def main(config_name):
 
     # init ether
     config_path = _get_config_path(config_name)
-    ether.init(config=config_path)
+    ether.tap(config=config_path)
 
     # use ether's start method to publish to the "start" topic
     # this will call any method decorated with @ether_start

--- a/src/scripts/benchmark.py
+++ b/src/scripts/benchmark.py
@@ -155,7 +155,7 @@ def run_benchmark(message_size: int, num_messages: int, num_subscribers: int, nu
         }
         
         # Initialize Ether system with configuration
-        ether.init(
+        ether.tap(
             config=config, 
             # quiet=True,
             restart=True

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -25,7 +25,7 @@ def run_mixed_autorun_test():
     }
     
     # Initialize - should only start generator
-    ether.init(config=config, restart=True)
+    ether.tap(config=config, restart=True)
     time.sleep(1)
     
     # Check that only generator is running
@@ -36,7 +36,7 @@ def run_mixed_autorun_test():
     
     # launch processor
     config["instances"]["test_processor"]["autorun"] = True
-    processes = ether.init(restart=True, config=config)
+    processes = ether.tap(restart=True, config=config)
     time.sleep(1)
     
     # Check both are running

--- a/src/tests/test_ether_get.py
+++ b/src/tests/test_ether_get.py
@@ -1,0 +1,121 @@
+import pytest
+import time
+from ether import ether
+from ether._internal._registry import _ether_get, _ether_request
+from ether.utils import _get_logger
+from typing import Optional, List
+from ether._internal._config import EtherConfig, EtherInstanceConfig
+
+@pytest.mark.skip(reason="Not a test class")
+class DataService:
+    def __init__(self):
+        self.data = {
+            1: {"name": "Item 1", "tags": ["a", "b"]},
+            2: {"name": "Item 2", "tags": ["b", "c"]},
+            3: {"name": "Item 3", "tags": ["a", "c"]}
+        }
+    
+    @_ether_get
+    def get_item(self, id: int) -> dict:
+        """Get a single item by ID"""
+        if id not in self.data:
+            raise KeyError(f"Item {id} not found")
+        return self.data[id]
+    
+    @_ether_get
+    def get_items_by_tag(self, tag: str, limit: Optional[int] = None) -> List[dict]:
+        """Get items that have a specific tag"""
+        items = [
+            {"id": id, **item}
+            for id, item in self.data.items()
+            if tag in item["tags"]
+        ]
+        if limit:
+            items = items[:limit]
+        return items
+    
+    @_ether_get
+    def get_stats(self) -> dict:
+        """Get stats about the data (no parameters)"""
+        return {
+            "total_items": len(self.data),
+            "total_tags": len(set(
+                tag 
+                for item in self.data.values() 
+                for tag in item["tags"]
+            ))
+        }
+
+def test_ether_get_with_params():
+    logger = _get_logger("TestEtherGet")
+    logger.debug("Starting Ether get test")
+    
+    # Create configuration
+    config = EtherConfig(
+        instances={
+            "data_service": EtherInstanceConfig(
+                class_path="tests.test_ether_get.DataService",
+                kwargs={"name": "data_service"}
+            )
+        }
+    )
+    
+    # Initialize Ether with config
+    ether.tap(config=config)
+    
+    try:
+        # Allow service to start
+        time.sleep(5.0)
+        
+        # Test get_item with valid ID
+        logger.debug("Testing get_item with valid ID")
+        result = _ether_request("DataService", "get_item", params={"id": 1})
+        logger.debug(f"get_item result: {result}")
+        assert result == {"name": "Item 1", "tags": ["a", "b"]}
+        
+        # Test get_item with invalid ID
+        logger.debug("Testing get_item with invalid ID")
+        with pytest.raises(Exception) as exc:
+            _ether_request("DataService", "get_item", params={"id": 999})
+        logger.debug(f"get_item error: {str(exc.value)}")
+        assert "Item 999 not found" in str(exc.value)
+        
+        # Test get_item with invalid parameter type
+        logger.debug("Testing get_item with invalid parameter type")
+        with pytest.raises(Exception) as exc:
+            _ether_request("DataService", "get_item", params={"id": "not an int"})
+        logger.debug(f"get_item validation error: {str(exc.value)}")
+        assert "Invalid parameters" in str(exc.value)
+        
+        # Test get_items_by_tag with required parameter
+        logger.debug("Testing get_items_by_tag with required parameter")
+        result = _ether_request("DataService", "get_items_by_tag", params={"tag": "b"})
+        logger.debug(f"get_items_by_tag result: {result}")
+        assert len(result) == 2
+        assert all("b" in item["tags"] for item in result)
+        
+        # Test get_items_by_tag with optional parameter
+        logger.debug("Testing get_items_by_tag with optional parameter")
+        result = _ether_request("DataService", "get_items_by_tag", 
+                              params={"tag": "b", "limit": 1})
+        logger.debug(f"get_items_by_tag with limit result: {result}")
+        assert len(result) == 1
+        assert "b" in result[0]["tags"]
+        
+        # Test get_stats with no parameters
+        logger.debug("Testing get_stats with no parameters")
+        result = _ether_request("DataService", "get_stats")
+        logger.debug(f"get_stats result: {result}")
+        assert result == {"total_items": 3, "total_tags": 3}
+        
+        # Test get_stats with unexpected parameter (should be ignored)
+        logger.debug("Testing get_stats with unexpected parameter")
+        result = _ether_request("DataService", "get_stats", params={"unexpected": "param"})
+        logger.debug(f"get_stats with unexpected param result: {result}")
+        assert result == {"total_items": 3, "total_tags": 3}
+        
+    finally:
+        ether.shutdown()
+
+if __name__ == '__main__':
+    pytest.main([__file__]) 

--- a/src/tests/test_ether_get.py
+++ b/src/tests/test_ether_get.py
@@ -6,7 +6,6 @@ from ether.utils import _get_logger
 from typing import Optional, List
 from ether._internal._config import EtherConfig, EtherInstanceConfig
 
-@pytest.mark.skip(reason="Not a test class")
 class DataService:
     def __init__(self):
         self.data = {

--- a/src/tests/test_ether_get.py
+++ b/src/tests/test_ether_get.py
@@ -64,8 +64,6 @@ def test_ether_get_with_params():
     ether.tap(config=config)
     
     try:
-        # Allow service to start
-        time.sleep(5.0)
         
         # Test get_item with valid ID
         logger.debug("Testing get_item with valid ID")

--- a/src/tests/test_ether_get.py
+++ b/src/tests/test_ether_get.py
@@ -71,17 +71,14 @@ def test_ether_get_with_params():
         
         # Test get_item with invalid ID
         logger.debug("Testing get_item with invalid ID")
-        with pytest.raises(Exception) as exc:
-            ether.get("DataService", "get_item", params={"id": 999})
-        logger.debug(f"get_item error: {str(exc.value)}")
-        assert "Item 999 not found" in str(exc.value)
+        
+        reply_invalid_id = ether.get("DataService", "get_item", params={"id": 999})
+        assert reply_invalid_id is None
         
         # Test get_item with invalid parameter type
         logger.debug("Testing get_item with invalid parameter type")
-        with pytest.raises(Exception) as exc:
-            ether.get("DataService", "get_item", params={"id": "not an int"})
-        logger.debug(f"get_item validation error: {str(exc.value)}")
-        assert "Invalid parameters" in str(exc.value)
+        reply_validation_error = ether.get("DataService", "get_item", params={"id": "not an int"})
+        assert reply_validation_error is None
         
         # Test get_items_by_tag with required parameter
         logger.debug("Testing get_items_by_tag with required parameter")

--- a/src/tests/test_ether_get.py
+++ b/src/tests/test_ether_get.py
@@ -1,7 +1,7 @@
 import pytest
 from ether import ether
 from ether import ether_get
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 from typing import Optional, List
 from ether._internal._config import EtherConfig, EtherInstanceConfig
 
@@ -45,7 +45,7 @@ class DataService:
         }
 
 def test_ether_get_with_params():
-    logger = _get_logger("TestEtherGet")
+    logger = get_ether_logger("TestEtherGet")
     logger.debug("Starting Ether get test")
     
     # Create configuration

--- a/src/tests/test_ether_get.py
+++ b/src/tests/test_ether_get.py
@@ -1,7 +1,6 @@
 import pytest
-import time
 from ether import ether
-from ether._internal._registry import _ether_get
+from ether import ether_get
 from ether.utils import _get_logger
 from typing import Optional, List
 from ether._internal._config import EtherConfig, EtherInstanceConfig
@@ -14,14 +13,14 @@ class DataService:
             3: {"name": "Item 3", "tags": ["a", "c"]}
         }
     
-    @_ether_get
+    @ether_get
     def get_item(self, id: int) -> dict:
         """Get a single item by ID"""
         if id not in self.data:
             raise KeyError(f"Item {id} not found")
         return self.data[id]
     
-    @_ether_get
+    @ether_get
     def get_items_by_tag(self, tag: str, limit: Optional[int] = None) -> List[dict]:
         """Get items that have a specific tag"""
         items = [
@@ -33,7 +32,7 @@ class DataService:
             items = items[:limit]
         return items
     
-    @_ether_get
+    @ether_get
     def get_stats(self) -> dict:
         """Get stats about the data (no parameters)"""
         return {
@@ -66,34 +65,34 @@ def test_ether_get_with_params():
         
         # Test get_item with valid ID
         logger.debug("Testing get_item with valid ID")
-        result = ether.request("DataService", "get_item", params={"id": 1})
+        result = ether.get("DataService", "get_item", params={"id": 1})
         logger.debug(f"get_item result: {result}")
         assert result == {"name": "Item 1", "tags": ["a", "b"]}
         
         # Test get_item with invalid ID
         logger.debug("Testing get_item with invalid ID")
         with pytest.raises(Exception) as exc:
-            ether.request("DataService", "get_item", params={"id": 999})
+            ether.get("DataService", "get_item", params={"id": 999})
         logger.debug(f"get_item error: {str(exc.value)}")
         assert "Item 999 not found" in str(exc.value)
         
         # Test get_item with invalid parameter type
         logger.debug("Testing get_item with invalid parameter type")
         with pytest.raises(Exception) as exc:
-            ether.request("DataService", "get_item", params={"id": "not an int"})
+            ether.get("DataService", "get_item", params={"id": "not an int"})
         logger.debug(f"get_item validation error: {str(exc.value)}")
         assert "Invalid parameters" in str(exc.value)
         
         # Test get_items_by_tag with required parameter
         logger.debug("Testing get_items_by_tag with required parameter")
-        result = ether.request("DataService", "get_items_by_tag", params={"tag": "b"})
+        result = ether.get("DataService", "get_items_by_tag", params={"tag": "b"})
         logger.debug(f"get_items_by_tag result: {result}")
         assert len(result) == 2
         assert all("b" in item["tags"] for item in result)
         
         # Test get_items_by_tag with optional parameter
         logger.debug("Testing get_items_by_tag with optional parameter")
-        result = ether.request("DataService", "get_items_by_tag", 
+        result = ether.get("DataService", "get_items_by_tag", 
                               params={"tag": "b", "limit": 1})
         logger.debug(f"get_items_by_tag with limit result: {result}")
         assert len(result) == 1
@@ -101,13 +100,13 @@ def test_ether_get_with_params():
         
         # Test get_stats with no parameters
         logger.debug("Testing get_stats with no parameters")
-        result = ether.request("DataService", "get_stats")
+        result = ether.get("DataService", "get_stats")
         logger.debug(f"get_stats result: {result}")
         assert result == {"total_items": 3, "total_tags": 3}
         
         # Test get_stats with unexpected parameter (should be ignored)
         logger.debug("Testing get_stats with unexpected parameter")
-        result = ether.request("DataService", "get_stats", params={"unexpected": "param"})
+        result = ether.get("DataService", "get_stats", params={"unexpected": "param"})
         logger.debug(f"get_stats with unexpected param result: {result}")
         assert result == {"total_items": 3, "total_tags": 3}
         

--- a/src/tests/test_ether_get.py
+++ b/src/tests/test_ether_get.py
@@ -1,7 +1,7 @@
 import pytest
 import time
 from ether import ether
-from ether._internal._registry import _ether_get, _ether_request
+from ether._internal._registry import _ether_get
 from ether.utils import _get_logger
 from typing import Optional, List
 from ether._internal._config import EtherConfig, EtherInstanceConfig
@@ -69,34 +69,34 @@ def test_ether_get_with_params():
         
         # Test get_item with valid ID
         logger.debug("Testing get_item with valid ID")
-        result = _ether_request("DataService", "get_item", params={"id": 1})
+        result = ether.request("DataService", "get_item", params={"id": 1})
         logger.debug(f"get_item result: {result}")
         assert result == {"name": "Item 1", "tags": ["a", "b"]}
         
         # Test get_item with invalid ID
         logger.debug("Testing get_item with invalid ID")
         with pytest.raises(Exception) as exc:
-            _ether_request("DataService", "get_item", params={"id": 999})
+            ether.request("DataService", "get_item", params={"id": 999})
         logger.debug(f"get_item error: {str(exc.value)}")
         assert "Item 999 not found" in str(exc.value)
         
         # Test get_item with invalid parameter type
         logger.debug("Testing get_item with invalid parameter type")
         with pytest.raises(Exception) as exc:
-            _ether_request("DataService", "get_item", params={"id": "not an int"})
+            ether.request("DataService", "get_item", params={"id": "not an int"})
         logger.debug(f"get_item validation error: {str(exc.value)}")
         assert "Invalid parameters" in str(exc.value)
         
         # Test get_items_by_tag with required parameter
         logger.debug("Testing get_items_by_tag with required parameter")
-        result = _ether_request("DataService", "get_items_by_tag", params={"tag": "b"})
+        result = ether.request("DataService", "get_items_by_tag", params={"tag": "b"})
         logger.debug(f"get_items_by_tag result: {result}")
         assert len(result) == 2
         assert all("b" in item["tags"] for item in result)
         
         # Test get_items_by_tag with optional parameter
         logger.debug("Testing get_items_by_tag with optional parameter")
-        result = _ether_request("DataService", "get_items_by_tag", 
+        result = ether.request("DataService", "get_items_by_tag", 
                               params={"tag": "b", "limit": 1})
         logger.debug(f"get_items_by_tag with limit result: {result}")
         assert len(result) == 1
@@ -104,13 +104,13 @@ def test_ether_get_with_params():
         
         # Test get_stats with no parameters
         logger.debug("Testing get_stats with no parameters")
-        result = _ether_request("DataService", "get_stats")
+        result = ether.request("DataService", "get_stats")
         logger.debug(f"get_stats result: {result}")
         assert result == {"total_items": 3, "total_tags": 3}
         
         # Test get_stats with unexpected parameter (should be ignored)
         logger.debug("Testing get_stats with unexpected parameter")
-        result = _ether_request("DataService", "get_stats", params={"unexpected": "param"})
+        result = ether.request("DataService", "get_stats", params={"unexpected": "param"})
         logger.debug(f"get_stats with unexpected param result: {result}")
         assert result == {"total_items": 3, "total_tags": 3}
         

--- a/src/tests/test_ether_multiservice.py
+++ b/src/tests/test_ether_multiservice.py
@@ -1,0 +1,208 @@
+import pytest
+import zmq
+import multiprocessing
+import time
+import json
+from ether import ether
+from ether._internal._reqrep import (
+    MDPC_CLIENT, 
+    MDPW_WORKER,
+    W_READY,
+    W_REQUEST, 
+    W_REPLY
+)
+from ether.utils import _get_logger
+
+def run_worker(service_name):
+    """Run a worker in a separate process"""
+    logger = _get_logger(f"Worker-{service_name.decode()}")
+    context = zmq.Context()
+    socket = context.socket(zmq.DEALER)
+    socket.setsockopt(zmq.RCVTIMEO, 2500)
+    socket.connect("tcp://localhost:5560")
+    
+    try:
+        # Register with broker
+        logger.debug(f"Registering worker for service {service_name}")
+        socket.send_multipart([
+            b'',
+            MDPW_WORKER,
+            W_READY,
+            service_name
+        ])
+        
+        # Process multiple requests
+        while True:
+            try:
+                msg = socket.recv_multipart()
+                logger.debug(f"Received request: {msg}")
+                
+                assert msg[1] == MDPW_WORKER
+                assert msg[2] == W_REQUEST
+                client_id = msg[3]
+                request = json.loads(msg[4].decode())
+                logger.debug(f"Decoded request: {request}")
+                
+                # Send reply with request details and service name
+                reply_data = {
+                    "result": "success",
+                    "service": service_name.decode(),
+                    "request_id": request["request_id"],
+                    "client_id": request["client_id"]
+                }
+                logger.debug(f"Sending reply: {reply_data}")
+                socket.send_multipart([
+                    b'',
+                    MDPW_WORKER,
+                    W_REPLY,
+                    service_name,
+                    client_id,
+                    json.dumps(reply_data).encode()
+                ])
+                
+            except zmq.error.Again:
+                # Normal timeout, return success
+                return True
+                
+    except Exception as e:
+        logger.error(f"Worker error: {e}")
+        return False
+    finally:
+        socket.close()
+        context.term()
+
+def run_client(client_id, services):
+    """Run a client that makes requests to multiple services"""
+    logger = _get_logger(f"Client-{client_id}")
+    context = zmq.Context()
+    socket = context.socket(zmq.DEALER)
+    socket.setsockopt(zmq.RCVTIMEO, 2500)
+    socket.connect("tcp://localhost:5559")
+    
+    try:
+        replies_received = {service: set() for service in services}
+        
+        # Send 3 requests to each service
+        for request_id in range(3):
+            for service_name in services:
+                request_data = {
+                    "action": "test",
+                    "request_id": request_id,
+                    "client_id": client_id,
+                    "service": service_name.decode()
+                }
+                logger.debug(f"Sending request {request_id} to service {service_name}")
+                socket.send_multipart([
+                    b'',
+                    MDPC_CLIENT,
+                    service_name,
+                    json.dumps(request_data).encode()
+                ])
+                
+                # Get reply
+                logger.debug(f"Waiting for reply from {service_name} for request {request_id}")
+                try:
+                    msg = socket.recv_multipart()
+                    logger.debug(f"Received reply: {msg}")
+                    
+                    assert msg[1] == MDPC_CLIENT
+                    assert msg[2] == service_name
+                    reply = json.loads(msg[3].decode())
+                    
+                    # Verify reply matches our request
+                    assert reply["result"] == "success"
+                    assert reply["service"] == service_name.decode()
+                    assert reply["request_id"] == request_id
+                    assert reply["client_id"] == client_id
+                    
+                    replies_received[service_name].add(request_id)
+                    
+                except zmq.error.Again:
+                    logger.error(f"Timeout waiting for reply from {service_name} to request {request_id}")
+                    return False
+        
+        # Verify we got all replies from all services
+        for service_name, replies in replies_received.items():
+            assert len(replies) == 3, f"Only received {len(replies)} replies from {service_name}"
+        return True
+            
+    except Exception as e:
+        logger.error(f"Client error: {e}")
+        return False
+    finally:
+        socket.close()
+        context.term()
+
+def test_multiple_services():
+    logger = _get_logger("TestMultiService")
+    logger.debug("Starting multi-service test")
+    
+    # Initialize Ether (this starts the broker)
+    ether.init()
+    
+    services = [b"service1", b"service2"]
+    processes = []
+    
+    try:
+        # Allow broker to initialize
+        time.sleep(0.5)
+        
+        # Start worker processes for each service
+        for service_name in services:
+            worker_process = multiprocessing.Process(
+                target=run_worker, 
+                args=(service_name,),
+                name=f"Worker-{service_name.decode()}"
+            )
+            worker_process.daemon = True
+            worker_process.start()
+            processes.append(worker_process)
+        
+        # Allow workers to register
+        time.sleep(1.0)
+        
+        # Start multiple client processes
+        client_processes = []
+        for client_id in range(2):
+            client_process = multiprocessing.Process(
+                target=run_client, 
+                args=(client_id, services),
+                name=f"Client-{client_id}"
+            )
+            client_process.daemon = True
+            client_process.start()
+            processes.append(client_process)
+            client_processes.append(client_process)
+        
+        # Wait for all clients to complete
+        for client_process in client_processes:
+            client_process.join(timeout=20)  # Increased timeout for multiple services
+            assert not client_process.is_alive(), f"Client process {client_process.name} timed out"
+            assert client_process.exitcode == 0, f"Client process {client_process.name} failed"
+        
+        # Allow workers to finish processing
+        time.sleep(0.5)
+        
+        # Signal workers to stop
+        for worker_process in processes[:2]:  # First two processes are workers
+            worker_process.join(timeout=2)
+            if worker_process.is_alive():
+                worker_process.terminate()
+                worker_process.join(timeout=1)
+        
+    finally:
+        logger.debug("Cleaning up test resources")
+        
+        # Terminate all processes
+        for p in processes:
+            if p.is_alive():
+                logger.debug(f"Terminating {p.name}")
+                p.terminate()
+                p.join(timeout=1)
+                if p.is_alive():
+                    logger.warning(f"Process {p.name} didn't terminate, killing")
+                    p.kill()
+                    p.join(timeout=1)
+
+if __name__ == '__main__':
+    pytest.main([__file__]) 

--- a/src/tests/test_ether_multiservice.py
+++ b/src/tests/test_ether_multiservice.py
@@ -18,11 +18,11 @@ from ether._internal._reqrep import (
     REPLY_SERVICE_INDEX,
     REPLY_DATA_INDEX
 )
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 
 def run_worker(service_name):
     """Run a worker in a separate process"""
-    logger = _get_logger(f"Worker-{service_name.decode()}")
+    logger = get_ether_logger(f"Worker-{service_name.decode()}")
     context = zmq.Context()
     socket = context.socket(zmq.DEALER)
     socket.setsockopt(zmq.RCVTIMEO, 2500)
@@ -80,7 +80,7 @@ def run_worker(service_name):
 
 def run_client(client_id, services):
     """Run a client that makes requests to multiple services"""
-    logger = _get_logger(f"Client-{client_id}")
+    logger = get_ether_logger(f"Client-{client_id}")
     context = zmq.Context()
     socket = context.socket(zmq.DEALER)
     socket.setsockopt(zmq.RCVTIMEO, 2500)
@@ -141,7 +141,7 @@ def run_client(client_id, services):
         context.term()
 
 def test_multiple_services():
-    logger = _get_logger("TestMultiService")
+    logger = get_ether_logger("TestMultiService")
     logger.debug("Starting multi-service test")
     
     # Initialize Ether (this starts the broker)

--- a/src/tests/test_ether_multiservice.py
+++ b/src/tests/test_ether_multiservice.py
@@ -9,7 +9,14 @@ from ether._internal._reqrep import (
     MDPW_WORKER,
     W_READY,
     W_REQUEST, 
-    W_REPLY
+    W_REPLY,
+    REQUEST_WORKER_INDEX,
+    REQUEST_COMMAND_INDEX,
+    REQUEST_CLIENT_ID_INDEX,
+    REQUEST_DATA_INDEX,
+    REPLY_CLIENT_INDEX,
+    REPLY_SERVICE_INDEX,
+    REPLY_DATA_INDEX
 )
 from ether.utils import _get_logger
 
@@ -37,10 +44,10 @@ def run_worker(service_name):
                 msg = socket.recv_multipart()
                 logger.debug(f"Received request: {msg}")
                 
-                assert msg[1] == MDPW_WORKER
-                assert msg[2] == W_REQUEST
-                client_id = msg[3]
-                request = json.loads(msg[4].decode())
+                assert msg[REQUEST_WORKER_INDEX] == MDPW_WORKER
+                assert msg[REQUEST_COMMAND_INDEX] == W_REQUEST
+                client_id = msg[REQUEST_CLIENT_ID_INDEX]
+                request = json.loads(msg[REQUEST_DATA_INDEX].decode())
                 logger.debug(f"Decoded request: {request}")
                 
                 # Send reply with request details and service name
@@ -105,9 +112,9 @@ def run_client(client_id, services):
                     msg = socket.recv_multipart()
                     logger.debug(f"Received reply: {msg}")
                     
-                    assert msg[1] == MDPC_CLIENT
-                    assert msg[2] == service_name
-                    reply = json.loads(msg[3].decode())
+                    assert msg[REPLY_CLIENT_INDEX] == MDPC_CLIENT
+                    assert msg[REPLY_SERVICE_INDEX] == service_name
+                    reply = json.loads(msg[REPLY_DATA_INDEX].decode())
                     
                     # Verify reply matches our request
                     assert reply["result"] == "success"

--- a/src/tests/test_ether_multiservice.py
+++ b/src/tests/test_ether_multiservice.py
@@ -145,7 +145,7 @@ def test_multiple_services():
     logger.debug("Starting multi-service test")
     
     # Initialize Ether (this starts the broker)
-    ether.init()
+    ether.tap()
     
     services = [b"service1", b"service2"]
     processes = []

--- a/src/tests/test_ether_multiservice.py
+++ b/src/tests/test_ether_multiservice.py
@@ -211,5 +211,7 @@ def test_multiple_services():
                     p.kill()
                     p.join(timeout=1)
 
+        ether.shutdown()
+
 if __name__ == '__main__':
     pytest.main([__file__]) 

--- a/src/tests/test_ether_reqrep.py
+++ b/src/tests/test_ether_reqrep.py
@@ -202,5 +202,7 @@ def test_ether_request_reply():
                     p.kill()
                     p.join(timeout=1)
 
+        ether.shutdown()
+
 if __name__ == '__main__':
     pytest.main([__file__]) 

--- a/src/tests/test_ether_reqrep.py
+++ b/src/tests/test_ether_reqrep.py
@@ -1,0 +1,199 @@
+import pytest
+import zmq
+import multiprocessing
+import time
+import json
+from ether import ether
+from ether._internal._reqrep import (
+    MDPC_CLIENT, 
+    MDPW_WORKER,
+    W_READY,
+    W_REQUEST, 
+    W_REPLY
+)
+from ether.utils import _get_logger
+
+def run_worker(service_name):
+    """Run a worker in a separate process"""
+    logger = _get_logger("Worker")
+    context = zmq.Context()
+    socket = context.socket(zmq.DEALER)
+    socket.setsockopt(zmq.RCVTIMEO, 2500)
+    socket.connect("tcp://localhost:5560")
+    
+    try:
+        # Register with broker
+        logger.debug("Registering worker")
+        socket.send_multipart([
+            b'',
+            MDPW_WORKER,
+            W_READY,
+            service_name
+        ])
+        
+        # Process multiple requests
+        while True:
+            try:
+                msg = socket.recv_multipart()
+                logger.debug(f"Received request: {msg}")
+                
+                assert msg[1] == MDPW_WORKER
+                assert msg[2] == W_REQUEST
+                client_id = msg[3]
+                request = json.loads(msg[4].decode())
+                logger.debug(f"Decoded request: {request}")
+                
+                # Send reply with request ID echoed back
+                reply_data = {
+                    "result": "success",
+                    "request_id": request["request_id"],
+                    "client_id": request["client_id"]
+                }
+                logger.debug(f"Sending reply: {reply_data}")
+                socket.send_multipart([
+                    b'',
+                    MDPW_WORKER,
+                    W_REPLY,
+                    service_name,
+                    client_id,
+                    json.dumps(reply_data).encode()
+                ])
+                
+            except zmq.error.Again:
+                # Normal timeout, return success
+                return True
+                
+    except Exception as e:
+        logger.error(f"Worker error: {e}")
+        return False
+    finally:
+        socket.close()
+        context.term()
+
+def run_client(service_name, client_id):
+    """Run a client in a separate process"""
+    logger = _get_logger(f"Client-{client_id}")
+    context = zmq.Context()
+    socket = context.socket(zmq.DEALER)
+    socket.setsockopt(zmq.RCVTIMEO, 2500)
+    socket.connect("tcp://localhost:5559")
+    
+    try:
+        replies_received = set()
+        
+        # Send 5 requests
+        for request_id in range(5):
+            request_data = {
+                "action": "test",
+                "request_id": request_id,
+                "client_id": client_id
+            }
+            logger.debug(f"Sending request {request_id}")
+            socket.send_multipart([
+                b'',
+                MDPC_CLIENT,
+                service_name,
+                json.dumps(request_data).encode()
+            ])
+            
+            # Get reply
+            logger.debug(f"Waiting for reply to request {request_id}")
+            try:
+                msg = socket.recv_multipart()
+                logger.debug(f"Received reply: {msg}")
+                
+                assert msg[1] == MDPC_CLIENT
+                assert msg[2] == service_name
+                reply = json.loads(msg[3].decode())
+                
+                # Verify reply matches our request
+                assert reply["result"] == "success"
+                assert reply["request_id"] == request_id
+                assert reply["client_id"] == client_id
+                
+                replies_received.add(request_id)
+                
+            except zmq.error.Again:
+                logger.error(f"Timeout waiting for reply to request {request_id}")
+                return False
+                
+        # Verify we got all replies
+        assert len(replies_received) == 5, f"Only received {len(replies_received)} replies"
+        return True
+            
+    except Exception as e:
+        logger.error(f"Client error: {e}")
+        return False
+    finally:
+        socket.close()
+        context.term()
+
+def test_ether_request_reply():
+    logger = _get_logger("TestEtherReqRep")
+    logger.debug("Starting Ether request-reply test")
+    
+    # Initialize Ether (this starts the broker)
+    ether.init()
+
+    time.sleep(5)
+    
+    service_name = b"test_service"
+    processes = []
+    
+    try:
+        # Allow broker to initialize
+        time.sleep(0.5)
+        
+        # Start worker process
+        worker_process = multiprocessing.Process(target=run_worker, args=(service_name,), name="Worker")
+        worker_process.daemon = True
+        worker_process.start()
+        processes.append(worker_process)
+        
+        # Allow worker to register
+        time.sleep(1.0)
+        
+        # Start multiple client processes
+        client_processes = []
+        for client_id in range(2):
+            client_process = multiprocessing.Process(
+                target=run_client, 
+                args=(service_name, client_id), 
+                name=f"Client-{client_id}"
+            )
+            client_process.daemon = True
+            client_process.start()
+            processes.append(client_process)
+            client_processes.append(client_process)
+        
+        # Wait for all clients to complete
+        for client_process in client_processes:
+            client_process.join(timeout=10)
+            assert not client_process.is_alive(), f"Client process {client_process.name} timed out"
+            assert client_process.exitcode == 0, f"Client process {client_process.name} failed"
+        
+        # Allow worker to finish processing
+        time.sleep(0.5)
+        
+        # Signal worker to stop by closing its socket (it will timeout and exit)
+        worker_process.join(timeout=2)
+        if worker_process.is_alive():
+            worker_process.terminate()
+            worker_process.join(timeout=1)
+        
+    finally:
+        logger.debug("Cleaning up test resources")
+        
+        # Terminate all processes
+        for p in processes:
+            if p.is_alive():
+                logger.debug(f"Terminating {p.name}")
+                p.terminate()
+                p.join(timeout=1)
+                if p.is_alive():
+                    logger.warning(f"Process {p.name} didn't terminate, killing")
+                    p.kill()
+                    p.join(timeout=1)
+
+if __name__ == '__main__':
+    pytest.main([__file__]) 

--- a/src/tests/test_ether_reqrep.py
+++ b/src/tests/test_ether_reqrep.py
@@ -140,7 +140,7 @@ def test_ether_request_reply():
     logger.debug("Starting Ether request-reply test")
     
     # Initialize Ether (this starts the broker)
-    ether.init()
+    ether.tap()
 
     time.sleep(5)
     

--- a/src/tests/test_ether_reqrep.py
+++ b/src/tests/test_ether_reqrep.py
@@ -18,11 +18,11 @@ from ether._internal._reqrep import (
     REQUEST_COMMAND_INDEX,
     REQUEST_CLIENT_ID_INDEX
 )
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 
 def run_worker(service_name):
     """Run a worker in a separate process"""
-    logger = _get_logger("Worker")
+    logger = get_ether_logger("Worker")
     context = zmq.Context()
     socket = context.socket(zmq.DEALER)
     socket.setsockopt(zmq.RCVTIMEO, 2500)
@@ -79,7 +79,7 @@ def run_worker(service_name):
 
 def run_client(service_name, client_id):
     """Run a client in a separate process"""
-    logger = _get_logger(f"Client-{client_id}")
+    logger = get_ether_logger(f"Client-{client_id}")
     context = zmq.Context()
     socket = context.socket(zmq.DEALER)
     socket.setsockopt(zmq.RCVTIMEO, 2500)
@@ -136,7 +136,7 @@ def run_client(service_name, client_id):
         context.term()
 
 def test_ether_request_reply():
-    logger = _get_logger("TestEtherReqRep")
+    logger = get_ether_logger("TestEtherReqRep")
     logger.debug("Starting Ether request-reply test")
     
     # Initialize Ether (this starts the broker)

--- a/src/tests/test_ether_reqrep.py
+++ b/src/tests/test_ether_reqrep.py
@@ -9,7 +9,14 @@ from ether._internal._reqrep import (
     MDPW_WORKER,
     W_READY,
     W_REQUEST, 
-    W_REPLY
+    W_REPLY,
+    REQUEST_DATA_INDEX,
+    REPLY_CLIENT_INDEX,
+    REPLY_SERVICE_INDEX,
+    REPLY_DATA_INDEX,
+    REQUEST_WORKER_INDEX,
+    REQUEST_COMMAND_INDEX,
+    REQUEST_CLIENT_ID_INDEX
 )
 from ether.utils import _get_logger
 
@@ -37,10 +44,10 @@ def run_worker(service_name):
                 msg = socket.recv_multipart()
                 logger.debug(f"Received request: {msg}")
                 
-                assert msg[1] == MDPW_WORKER
-                assert msg[2] == W_REQUEST
-                client_id = msg[3]
-                request = json.loads(msg[4].decode())
+                assert msg[REQUEST_WORKER_INDEX] == MDPW_WORKER
+                assert msg[REQUEST_COMMAND_INDEX] == W_REQUEST
+                client_id = msg[REQUEST_CLIENT_ID_INDEX]
+                request = json.loads(msg[REQUEST_DATA_INDEX].decode())
                 logger.debug(f"Decoded request: {request}")
                 
                 # Send reply with request ID echoed back
@@ -102,9 +109,9 @@ def run_client(service_name, client_id):
                 msg = socket.recv_multipart()
                 logger.debug(f"Received reply: {msg}")
                 
-                assert msg[1] == MDPC_CLIENT
-                assert msg[2] == service_name
-                reply = json.loads(msg[3].decode())
+                assert msg[REPLY_CLIENT_INDEX] == MDPC_CLIENT
+                assert msg[REPLY_SERVICE_INDEX] == service_name
+                reply = json.loads(msg[REPLY_DATA_INDEX].decode())
                 
                 # Verify reply matches our request
                 assert reply["result"] == "success"

--- a/src/tests/test_ether_reqrep_advanced.py
+++ b/src/tests/test_ether_reqrep_advanced.py
@@ -3,19 +3,18 @@ import time
 from typing import List, Optional
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
-from ether._internal._registry import _ether_get, _ether_save
+from ether import ether_get, ether_save  
 from ether.utils import get_ether_logger
 import zmq
 from ether.liaison import EtherInstanceLiaison
 
-@pytest.mark.skip(reason="Not a test class")
 class HeartbeatService:
     def __init__(self):
         self.data = {}
         self.counter = 0
         self.slow_until = 0
     
-    @_ether_get(heartbeat=True)  # Enable heartbeats
+    @ether_get(heartbeat=True)  # Changed from _ether_get
     def get_count(self) -> int:
         """Get current counter value"""
         # Add artificial delay if we're in slow mode
@@ -23,13 +22,13 @@ class HeartbeatService:
             time.sleep(0.1)  # Sleep 100ms
         return self.counter
     
-    @_ether_save(heartbeat=True)  # Enable heartbeats
+    @ether_save(heartbeat=True)  # Changed from _ether_save
     def increment(self, amount: int = 1) -> dict:
         """Increment counter by amount"""
         self.counter += amount
         return {"counter": self.counter}
     
-    @_ether_save(heartbeat=True)
+    @ether_save(heartbeat=True)  # Changed from _ether_save
     def set_slow(self, duration: float = 1.0) -> dict:
         """Make the service slow for a duration"""
         self.slow_until = time.time() + duration

--- a/src/tests/test_ether_reqrep_advanced.py
+++ b/src/tests/test_ether_reqrep_advanced.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
 from ether._internal._registry import _ether_get, _ether_save
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 import zmq
 from ether.liaison import EtherInstanceLiaison
 
@@ -36,7 +36,7 @@ class HeartbeatService:
         return {"slow_until": self.slow_until}
 
 def test_heartbeat_and_reconnect():
-    logger = _get_logger("TestHeartbeat")
+    logger = get_ether_logger("TestHeartbeat")
     
     # Setup retry counting
     retry_count = 0

--- a/src/tests/test_ether_reqrep_advanced.py
+++ b/src/tests/test_ether_reqrep_advanced.py
@@ -65,21 +65,20 @@ def test_heartbeat_and_reconnect():
     
     try:
         # Test basic request-reply with heartbeat
-        result = ether.request("HeartbeatService", "get_count")
+        result = ether.get("HeartbeatService", "get_count")
         assert result == 0
         
         # Test save with heartbeat
-        reply = ether.request(
+        reply = ether.save(
             "HeartbeatService", 
             "increment", 
             params={"amount": 5},
-            request_type="save"
         )
         assert reply["status"] == "success"
         assert reply["result"]["counter"] == 5
         
         # Verify counter was updated
-        result = ether.request("HeartbeatService", "get_count")
+        result = ether.get("HeartbeatService", "get_count")
         assert result == 5
         
         # Let heartbeats happen
@@ -87,11 +86,11 @@ def test_heartbeat_and_reconnect():
         time.sleep(3.0)  # Allow multiple heartbeat cycles
         
         # Test another request after heartbeats
-        result = ether.request("HeartbeatService", "get_count")
+        result = ether.get("HeartbeatService", "get_count")
         assert result == 5
         
         # Make service slow
-        reply = ether.request(
+        reply = ether.get(
             "HeartbeatService",
             "set_slow",
             params={"duration": 1.0},
@@ -105,7 +104,7 @@ def test_heartbeat_and_reconnect():
         
         start_time = time.time()
         try:
-            result = ether.request(
+            result = ether.get(
                 "HeartbeatService", 
                 "get_count", 
                 timeout=50  # 50ms timeout
@@ -120,7 +119,7 @@ def test_heartbeat_and_reconnect():
         assert retry_count > 1, f"Expected multiple retries, got {retry_count}"
         
         # Verify service still works
-        result = ether.request("HeartbeatService", "get_count")
+        result = ether.get("HeartbeatService", "get_count")
         assert result == 5  # Service should still be working
         
         # Test reconnection
@@ -142,7 +141,7 @@ def test_heartbeat_and_reconnect():
         # Send disconnect command to broker
         logger.info("Sending disconnect command...")
         try:
-            ether.request(
+            ether.get(
                 "HeartbeatService",
                 "get_count",
                 timeout=1  # Very short timeout to force disconnect
@@ -153,7 +152,7 @@ def test_heartbeat_and_reconnect():
         time.sleep(0.5)  # Allow more time for reconnect
         
         # Verify service still works after reconnect
-        result = ether.request("HeartbeatService", "get_count")
+        result = ether.get("HeartbeatService", "get_count")
         assert result == 5  # Service should still work
         
         # Verify instance is still registered

--- a/src/tests/test_ether_reqrep_advanced.py
+++ b/src/tests/test_ether_reqrep_advanced.py
@@ -1,0 +1,131 @@
+import pytest
+import time
+from typing import List, Optional
+from ether import ether
+from ether._internal._config import EtherConfig, EtherInstanceConfig
+from ether._internal._registry import _ether_get, _ether_save
+from ether.utils import _get_logger
+import zmq
+
+@pytest.mark.skip(reason="Not a test class")
+class HeartbeatService:
+    def __init__(self):
+        self.data = {}
+        self.counter = 0
+        self.slow_until = 0
+    
+    @_ether_get(heartbeat=True)  # Enable heartbeats
+    def get_count(self) -> int:
+        """Get current counter value"""
+        # Add artificial delay if we're in slow mode
+        if time.time() < self.slow_until:
+            time.sleep(0.1)  # Sleep 100ms
+        return self.counter
+    
+    @_ether_save(heartbeat=True)  # Enable heartbeats
+    def increment(self, amount: int = 1) -> dict:
+        """Increment counter by amount"""
+        self.counter += amount
+        return {"counter": self.counter}
+    
+    @_ether_save(heartbeat=True)
+    def set_slow(self, duration: float = 1.0) -> dict:
+        """Make the service slow for a duration"""
+        self.slow_until = time.time() + duration
+        return {"slow_until": self.slow_until}
+
+def test_heartbeat_and_reconnect():
+    logger = _get_logger("TestHeartbeat")
+    
+    # Setup retry counting
+    retry_count = 0
+    original_recv_multipart = zmq.Socket.recv_multipart
+    
+    def counting_recv_multipart(self, *args, **kwargs):
+        nonlocal retry_count
+        try:
+            return original_recv_multipart(self, *args, **kwargs)
+        except zmq.error.Again:
+            retry_count += 1
+            raise
+            
+    zmq.Socket.recv_multipart = counting_recv_multipart
+    
+    config = EtherConfig(
+        instances={
+            "heartbeat_service": EtherInstanceConfig(
+                class_path="tests.test_ether_reqrep_advanced.HeartbeatService",
+                kwargs={"name": "heartbeat_service"}
+            )
+        }
+    )
+    
+    ether.tap(config=config)
+    
+    try:
+        # Test basic request-reply with heartbeat
+        result = ether.request("HeartbeatService", "get_count")
+        assert result == 0
+        
+        # Test save with heartbeat
+        reply = ether.request(
+            "HeartbeatService", 
+            "increment", 
+            params={"amount": 5},
+            request_type="save"
+        )
+        assert reply["status"] == "success"
+        assert reply["result"]["counter"] == 5
+        
+        # Verify counter was updated
+        result = ether.request("HeartbeatService", "get_count")
+        assert result == 5
+        
+        # Let heartbeats happen
+        logger.info("Waiting for heartbeats...")
+        time.sleep(3.0)  # Allow multiple heartbeat cycles
+        
+        # Test another request after heartbeats
+        result = ether.request("HeartbeatService", "get_count")
+        assert result == 5
+        
+        # Make service slow
+        reply = ether.request(
+            "HeartbeatService",
+            "set_slow",
+            params={"duration": 1.0},
+            request_type="save"
+        )
+        assert reply["status"] == "success"
+        
+        # Test timeout and retry behavior
+        logger.info("Testing timeout handling...")
+        retry_count = 0  # Reset counter
+        
+        start_time = time.time()
+        try:
+            result = ether.request(
+                "HeartbeatService", 
+                "get_count", 
+                timeout=50  # 50ms timeout
+            )
+        except Exception as e:
+            logger.info(f"Request failed as expected: {e}")
+        
+        end_time = time.time()
+        elapsed = end_time - start_time
+        
+        logger.info(f"Request had {retry_count} retries over {elapsed:.3f}s")
+        assert retry_count > 1, f"Expected multiple retries, got {retry_count}"
+        
+        # Verify service still works
+        result = ether.request("HeartbeatService", "get_count")
+        assert result == 5  # Service should still be working
+        
+    finally:
+        # Restore original method
+        zmq.Socket.recv_multipart = original_recv_multipart
+        ether.shutdown()
+
+if __name__ == '__main__':
+    pytest.main([__file__]) 

--- a/src/tests/test_ether_reqrep_flow.py
+++ b/src/tests/test_ether_reqrep_flow.py
@@ -1,0 +1,91 @@
+import pytest
+import time
+from typing import List, Optional
+from ether import ether
+from ether._internal._config import EtherConfig, EtherInstanceConfig
+from ether._internal._registry import _ether_get, _ether_save
+from ether.utils import _get_logger
+from ether.liaison import EtherInstanceLiaison
+
+@pytest.mark.skip(reason="Not a test class")
+class FlowControlService:
+    def __init__(self):
+        self.requests = []
+        self.replies = []
+    
+    @_ether_get(heartbeat=True)
+    def get_request_history(self) -> List[dict]:
+        """Get history of requests and replies"""
+        return {
+            "requests": self.requests,
+            "replies": self.replies
+        }
+    
+    @_ether_save(heartbeat=True)
+    def process_request(self, data: str) -> dict:
+        """Process a request and track message flow"""
+        # Store request info
+        self.requests.append({
+            "data": data,
+            "time": time.time()
+        })
+        
+        # Create reply
+        reply = {
+            "processed_data": f"Processed: {data}",
+            "time": time.time()
+        }
+        self.replies.append(reply)
+        
+        return reply
+
+def test_message_flow_control():
+    logger = _get_logger("TestFlowControl")
+    
+    config = EtherConfig(
+        instances={
+            "flow_service": EtherInstanceConfig(
+                class_path="tests.test_ether_reqrep_flow.FlowControlService",
+                kwargs={"name": "flow_service"}
+            )
+        }
+    )
+    
+    ether.tap(config=config)
+    
+    try:
+        # Make several requests
+        test_data = ["request1", "request2", "request3"]
+        replies = []
+        
+        for data in test_data:
+            reply = ether.request(
+                "FlowControlService",
+                "process_request",
+                params={"data": data},
+                request_type="save"
+            )
+            assert reply["status"] == "success"
+            replies.append(reply["result"])
+        
+        # Get request history
+        history = ether.request("FlowControlService", "get_request_history")
+        
+        # Verify request/reply matching
+        assert len(history["requests"]) == len(test_data)
+        assert len(history["replies"]) == len(test_data)
+        
+        # Verify request order maintained
+        for i, data in enumerate(test_data):
+            assert history["requests"][i]["data"] == data
+            assert history["replies"][i]["processed_data"] == f"Processed: {data}"
+        
+        # Verify timing - replies should come after requests
+        for req, rep in zip(history["requests"], history["replies"]):
+            assert rep["time"] >= req["time"], "Reply came before request"
+            
+    finally:
+        ether.shutdown()
+
+if __name__ == '__main__':
+    pytest.main([__file__]) 

--- a/src/tests/test_ether_reqrep_flow.py
+++ b/src/tests/test_ether_reqrep_flow.py
@@ -3,7 +3,7 @@ import time
 from typing import List, Optional
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
-from ether._internal._registry import _ether_get, _ether_save
+from ether import ether_get, ether_save
 from ether.utils import _get_logger
 from ether.liaison import EtherInstanceLiaison
 
@@ -12,7 +12,7 @@ class FlowControlService:
         self.requests = []
         self.replies = []
     
-    @_ether_get(heartbeat=True)
+    @ether_get(heartbeat=True)
     def get_request_history(self) -> List[dict]:
         """Get history of requests and replies"""
         return {
@@ -20,7 +20,7 @@ class FlowControlService:
             "replies": self.replies
         }
     
-    @_ether_save(heartbeat=True)
+    @ether_save(heartbeat=True)
     def process_request(self, data: str) -> dict:
         """Process a request and track message flow"""
         # Store request info
@@ -58,17 +58,16 @@ def test_message_flow_control():
         replies = []
         
         for data in test_data:
-            reply = ether.request(
+            reply = ether.save(
                 "FlowControlService",
                 "process_request",
                 params={"data": data},
-                request_type="save"
             )
             assert reply["status"] == "success"
             replies.append(reply["result"])
         
         # Get request history
-        history = ether.request("FlowControlService", "get_request_history")
+        history = ether.get("FlowControlService", "get_request_history")
         
         # Verify request/reply matching
         assert len(history["requests"]) == len(test_data)

--- a/src/tests/test_ether_reqrep_flow.py
+++ b/src/tests/test_ether_reqrep_flow.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
 from ether import ether_get, ether_save
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 from ether.liaison import EtherInstanceLiaison
 
 class FlowControlService:
@@ -39,7 +39,7 @@ class FlowControlService:
         return reply
 
 def test_message_flow_control():
-    logger = _get_logger("TestFlowControl")
+    logger = get_ether_logger("TestFlowControl")
     
     config = EtherConfig(
         instances={

--- a/src/tests/test_ether_reqrep_flow.py
+++ b/src/tests/test_ether_reqrep_flow.py
@@ -7,7 +7,6 @@ from ether._internal._registry import _ether_get, _ether_save
 from ether.utils import _get_logger
 from ether.liaison import EtherInstanceLiaison
 
-@pytest.mark.skip(reason="Not a test class")
 class FlowControlService:
     def __init__(self):
         self.requests = []

--- a/src/tests/test_ether_save.py
+++ b/src/tests/test_ether_save.py
@@ -3,7 +3,7 @@ import time
 from typing import List
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
-from ether._internal._registry import _ether_request, _ether_save, _ether_get
+from ether._internal._registry import _ether_save, _ether_get
 from ether.utils import _get_logger
 
 @pytest.mark.skip(reason="Not a test class")
@@ -48,7 +48,7 @@ def test_ether_save():
         time.sleep(5.0)
         
         # Test saving new item
-        reply = _ether_request(
+        reply = ether.request(
             "DataService", 
             "save_item", 
             params={
@@ -64,14 +64,14 @@ def test_ether_save():
         assert result["name"] == "Test Item"
         
         # Verify item was saved
-        item = _ether_request("DataService", "get_item", params={"id": 1})
+        item = ether.request("DataService", "get_item", params={"id": 1})
         logger.info(f"Get item: {item}")
         assert item["name"] == "Test Item"
         assert item["tags"] == ["test", "new"]
         
         # Test saving duplicate item
 
-        reply =_ether_request(
+        reply = ether.request(
             "DataService", 
             "save_item", 
             params={

--- a/src/tests/test_ether_save.py
+++ b/src/tests/test_ether_save.py
@@ -1,0 +1,89 @@
+import pytest
+import time
+from typing import List
+from ether import ether
+from ether._internal._config import EtherConfig, EtherInstanceConfig
+from ether._internal._registry import _ether_request, _ether_save, _ether_get
+from ether.utils import _get_logger
+
+@pytest.mark.skip(reason="Not a test class")
+class DataService:
+    def __init__(self):
+        self.data = {}
+    
+    @_ether_save
+    def save_item(self, id: int, name: str, tags: List[str]) -> dict:
+        """Save an item to the data store"""
+        if id in self.data:
+            raise ValueError(f"Item {id} already exists")
+            
+        self.data[id] = {
+            "name": name,
+            "tags": tags
+        }
+        return self.data[id]  # Return saved item
+
+    @_ether_get
+    def get_item(self, id: int) -> dict:
+        """Get a single item by ID"""
+        if id not in self.data:
+            raise KeyError(f"Item {id} not found")
+        return self.data[id]
+
+def test_ether_save():
+    logger = _get_logger("TestEtherSave")
+    
+    config = EtherConfig(
+        instances={
+            "data_service": EtherInstanceConfig(
+                class_path="tests.test_ether_save.DataService",
+                kwargs={"name": "data_service"}
+            )
+        }
+    )
+    
+    ether.tap(config=config)
+    
+    try:
+        time.sleep(5.0)
+        
+        # Test saving new item
+        reply = _ether_request(
+            "DataService", 
+            "save_item", 
+            params={
+                "id": 1,
+                "name": "Test Item",
+                "tags": ["test", "new"]
+            },
+            request_type="save"
+        )
+        logger.info(f"Save reply: {reply}")
+        assert reply["status"] == "success"
+        result = reply["result"]
+        assert result["name"] == "Test Item"
+        
+        # Verify item was saved
+        item = _ether_request("DataService", "get_item", params={"id": 1})
+        logger.info(f"Get item: {item}")
+        assert item["name"] == "Test Item"
+        assert item["tags"] == ["test", "new"]
+        
+        # Test saving duplicate item
+
+        reply =_ether_request(
+            "DataService", 
+            "save_item", 
+            params={
+                "id": 1,
+                "name": "Duplicate",
+                "tags": []
+            },
+            request_type="save"
+        )
+        logger.info(f"Duplicate save reply: {reply}")
+        assert reply["status"] == "error"
+        assert "already exists" in str(reply["error"])
+        
+    finally:
+        ether.shutdown() 

--- a/src/tests/test_ether_save.py
+++ b/src/tests/test_ether_save.py
@@ -1,12 +1,9 @@
-import pytest
-import time
 from typing import List
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
 from ether._internal._registry import _ether_save, _ether_get
 from ether.utils import _get_logger
 
-@pytest.mark.skip(reason="Not a test class")
 class DataService:
     def __init__(self):
         self.data = {}

--- a/src/tests/test_ether_save.py
+++ b/src/tests/test_ether_save.py
@@ -2,7 +2,7 @@ from typing import List
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
 from ether import ether_save, ether_get
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 
 class DataService:
     def __init__(self):
@@ -28,7 +28,7 @@ class DataService:
         return self.data[id]
 
 def test_ether_save():
-    logger = _get_logger("TestEtherSave")
+    logger = get_ether_logger("TestEtherSave")
     
     config = EtherConfig(
         instances={

--- a/src/tests/test_ether_save.py
+++ b/src/tests/test_ether_save.py
@@ -11,7 +11,7 @@ class DataService:
     def __init__(self):
         self.data = {}
     
-    @_ether_save
+    @_ether_save(heartbeat=True)
     def save_item(self, id: int, name: str, tags: List[str]) -> dict:
         """Save an item to the data store"""
         if id in self.data:
@@ -45,7 +45,6 @@ def test_ether_save():
     ether.tap(config=config)
     
     try:
-        time.sleep(5.0)
         
         # Test saving new item
         reply = ether.request(

--- a/src/tests/test_ether_save.py
+++ b/src/tests/test_ether_save.py
@@ -1,14 +1,14 @@
 from typing import List
 from ether import ether
 from ether._internal._config import EtherConfig, EtherInstanceConfig
-from ether._internal._registry import _ether_save, _ether_get
+from ether import ether_save, ether_get
 from ether.utils import _get_logger
 
 class DataService:
     def __init__(self):
         self.data = {}
     
-    @_ether_save(heartbeat=True)
+    @ether_save(heartbeat=True)
     def save_item(self, id: int, name: str, tags: List[str]) -> dict:
         """Save an item to the data store"""
         if id in self.data:
@@ -20,7 +20,7 @@ class DataService:
         }
         return self.data[id]  # Return saved item
 
-    @_ether_get
+    @ether_get
     def get_item(self, id: int) -> dict:
         """Get a single item by ID"""
         if id not in self.data:
@@ -44,7 +44,7 @@ def test_ether_save():
     try:
         
         # Test saving new item
-        reply = ether.request(
+        reply = ether.save(
             "DataService", 
             "save_item", 
             params={
@@ -52,7 +52,6 @@ def test_ether_save():
                 "name": "Test Item",
                 "tags": ["test", "new"]
             },
-            request_type="save"
         )
         logger.info(f"Save reply: {reply}")
         assert reply["status"] == "success"
@@ -60,14 +59,14 @@ def test_ether_save():
         assert result["name"] == "Test Item"
         
         # Verify item was saved
-        item = ether.request("DataService", "get_item", params={"id": 1})
+        item = ether.get("DataService", "get_item", params={"id": 1})
         logger.info(f"Get item: {item}")
         assert item["name"] == "Test Item"
         assert item["tags"] == ["test", "new"]
         
         # Test saving duplicate item
 
-        reply = ether.request(
+        reply = ether.save(
             "DataService", 
             "save_item", 
             params={
@@ -75,7 +74,6 @@ def test_ether_save():
                 "name": "Duplicate",
                 "tags": []
             },
-            request_type="save"
         )
         logger.info(f"Duplicate save reply: {reply}")
         assert reply["status"] == "error"

--- a/src/tests/test_external_integration.py
+++ b/src/tests/test_external_integration.py
@@ -59,7 +59,7 @@ def test_external_integration():
     }
     
     # Initialize Ether with test configuration
-    ether.init(config=config_dict)
+    ether.tap(config=config_dict)
     
     # Give time for instances to start
     time.sleep(0.1)

--- a/src/tests/test_manual_generator.py
+++ b/src/tests/test_manual_generator.py
@@ -36,7 +36,7 @@ def run_manual_generator_test():
     }
     
     # Initialize system and start processor/collector
-    ether.init(config)
+    ether.tap(config)
     
     # Verify processor and collector are running
     instances = tracker.get_active_instances()

--- a/src/tests/test_message_data.py
+++ b/src/tests/test_message_data.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pydantic import BaseModel
 from ether import ether, ether_pub, ether_sub, ether_save
 from ether.liaison import EtherInstanceLiaison
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 from pprint import pprint
 
 # Test Models
@@ -20,7 +20,7 @@ class ComplexMessage(BaseModel):
 class DataVerificationPublisher:
     """Publisher that sends messages with verifiable data"""
     def __init__(self):
-        self._logger = _get_logger(self.__class__.__name__)
+        self._logger = get_ether_logger(self.__class__.__name__)
     
     @ether_pub(topic="complex_data")
     def send_complex_data(self) -> ComplexMessage:
@@ -54,7 +54,7 @@ class ReceivedData(BaseModel):
 class DataVerificationSubscriber:
     """Subscriber that verifies received message data"""
     def __init__(self):
-        self._logger = _get_logger(self.__class__.__name__)
+        self._logger = get_ether_logger(self.__class__.__name__)
         self.received_data = ReceivedData()
         self.liaison = EtherInstanceLiaison()
 

--- a/src/tests/test_message_data.py
+++ b/src/tests/test_message_data.py
@@ -127,7 +127,7 @@ def run_data_verification_test():
     
     try:
         # Initialize system
-        ether.init(config=config, restart=True)
+        ether.tap(config=config, restart=True)
         time.sleep(1.0)  # Allow time for setup
         
         # Create publisher and send messages

--- a/src/tests/test_pubsub_simple_data_processing.py
+++ b/src/tests/test_pubsub_simple_data_processing.py
@@ -9,7 +9,7 @@ from ether.liaison import EtherInstanceLiaison
 def run_instance_tracking_test():
     """Run instance tracking test in a separate process"""
     # Initialize Ether system with force_reinit
-    ether.init(restart=True)
+    ether.tap(restart=True)
     time.sleep(1)  # Wait for services to start
     
     # Create instances
@@ -58,7 +58,7 @@ def run_instance_tracking_test():
 def run_instance_ttl_test():
     """Run TTL test in a separate process"""
     # Initialize with force_reinit
-    ether.init(restart=True)
+    ether.tap(restart=True)
     
     # Create instance
     generator = DataGenerator(process_id=1)

--- a/src/tests/test_reconnect.py
+++ b/src/tests/test_reconnect.py
@@ -1,0 +1,107 @@
+import pytest
+import time
+from typing import Optional
+from ether import ether, ether_get, ether_save, _ether
+from ether._internal._config import EtherConfig, EtherInstanceConfig
+from ether.utils import get_ether_logger
+from ether.liaison import EtherInstanceLiaison
+from ether._internal._reqrep import MDPW_WORKER, W_DISCONNECT
+
+class ReconnectTestService:
+    def __init__(self):
+        self.counter = 0
+        self.connection_count = 0
+        
+    @ether_get(heartbeat=True)
+    def get_counter(self) -> dict:
+        """Get current counter value"""
+        self._logger.debug(f"Get counter called, value={self.counter}")
+        return {
+            "counter": self.counter,
+            "connection": self.connection_count
+        }
+        
+    @ether_save(heartbeat=True)
+    def increment(self) -> dict:
+        """Increment counter"""
+        self.counter += 1
+        self._logger.debug(f"Counter incremented to {self.counter}")
+        return {"counter": self.counter}
+
+def test_service_reconnect():
+    """Test that service properly reconnects after disconnect"""
+    logger = get_ether_logger("TestReconnect")
+    
+    config = EtherConfig(
+        instances={
+            "reconnect_service": EtherInstanceConfig(
+                class_path="tests.test_reconnect.ReconnectTestService",
+                kwargs={"name": "reconnect_service"}
+            )
+        }
+    )
+    
+    ether.tap(config=config)
+    
+    try:
+        # Initial connection
+        logger.info("Testing initial connection...")
+        result = ether.get("ReconnectTestService", "get_counter")
+        assert result["counter"] == 0
+        assert result["connection"] == 0
+        
+        # Make some requests
+        logger.info("Making initial requests...")
+        for _ in range(3):
+            ether.save("ReconnectTestService", "increment")
+            time.sleep(0.1)  # Small delay between requests
+            
+        result = ether.get("ReconnectTestService", "get_counter")
+        assert result["counter"] == 3
+        assert result["connection"] == 0
+        
+        # Force disconnect
+        # logger.info("Forcing disconnect...")
+        # result = _ether._disconnect_req_service("ReconnectTestService")
+        # logger.info(f"Disconnect reply: {result}")
+        # Wait for reconnect
+        time.sleep(3.0)  # Allow time for reconnect
+        
+        # Verify service is still accessible
+        logger.info("Verifying service after reconnect...")
+        result = ether.get("ReconnectTestService", "get_counter")
+        logger.info(f"Result after reconnect: {result}")
+        assert result["counter"] == 3  # Counter should be preserved
+        # assert result["connection"] == 1  # Should have reconnected once
+        
+        # Make more requests after reconnect
+        logger.info("Making requests after reconnect...")
+        for _ in range(2):
+            ether.save("ReconnectTestService", "increment")
+            time.sleep(0.1)
+            
+        result = ether.get("ReconnectTestService", "get_counter")
+        assert result["counter"] == 5  # Should continue from previous value
+        # assert result["connection"] == 1
+        
+        # Force another disconnect
+        # logger.info("Testing multiple disconnects...")
+        # ether.save("ReconnectTestService", "force_disconnect")
+        # time.sleep(2.0)
+        
+        # result = ether.get("ReconnectTestService", "get_counter")
+        # assert result["counter"] == 5
+        # assert result["connection"] == 2  # Should have reconnected twice
+        
+        # Verify heartbeats still working
+        logger.info("Verifying heartbeats after reconnects...")
+        time.sleep(3.0)  # Wait for several heartbeat cycles
+        result = ether.get("ReconnectTestService", "get_counter")
+        assert result["counter"] == 5
+        # assert result["connection"] == 2
+        
+    finally:
+        ether.shutdown()
+
+if __name__ == "__main__":
+    pytest.main([__file__]) 

--- a/src/tests/test_reqrep.py
+++ b/src/tests/test_reqrep.py
@@ -11,7 +11,7 @@ from ether._internal._reqrep import (
     W_REQUEST, 
     W_REPLY
 )
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 
 def run_broker():
     """Run the broker in a separate process"""
@@ -25,7 +25,7 @@ def run_broker():
 
 def run_worker(service_name):
     """Run a worker in a separate process"""
-    logger = _get_logger("Worker")
+    logger = get_ether_logger("Worker")
     context = zmq.Context()
     socket = context.socket(zmq.DEALER)
     socket.setsockopt(zmq.RCVTIMEO, 2500)
@@ -82,7 +82,7 @@ def run_worker(service_name):
 
 def run_client(service_name, client_id):
     """Run a client in a separate process"""
-    logger = _get_logger(f"Client-{client_id}")
+    logger = get_ether_logger(f"Client-{client_id}")
     context = zmq.Context()
     socket = context.socket(zmq.DEALER)
     socket.setsockopt(zmq.RCVTIMEO, 2500)
@@ -139,7 +139,7 @@ def run_client(service_name, client_id):
         context.term()
 
 def test_basic_request_reply():
-    logger = _get_logger("TestReqRep")
+    logger = get_ether_logger("TestReqRep")
     logger.debug("Starting request-reply test")
     
     service_name = b"test_service"

--- a/src/tests/test_reqrep.py
+++ b/src/tests/test_reqrep.py
@@ -1,0 +1,114 @@
+import pytest
+import zmq
+import multiprocessing
+import time
+import json
+from ether._internal._reqrep import EtherReqRepBroker, WORKER_READY, REQUEST, REPLY
+from ether.utils import _get_logger
+
+def run_broker():
+    """Run the broker in a separate process"""
+    broker = EtherReqRepBroker(frontend_port=5559, backend_port=5560)
+    try:
+        broker.run()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        broker.cleanup()
+
+def test_basic_request_reply():
+    logger = _get_logger("TestReqRep")
+    logger.debug("Starting request-reply test")
+    
+    # Start broker in separate process
+    broker_process = multiprocessing.Process(target=run_broker)
+    broker_process.daemon = True
+    broker_process.start()
+    
+    try:
+        # Allow broker to initialize
+        time.sleep(0.1)
+        logger.debug("Setting up worker socket")
+        
+        # Setup worker with timeout
+        worker_context = zmq.Context()
+        worker_socket = worker_context.socket(zmq.DEALER)
+        worker_socket.setsockopt(zmq.RCVTIMEO, 1000)  # 1 second timeout
+        worker_socket.connect("tcp://localhost:5560")
+        
+        # Worker registers with broker
+        service_name = b"test_service"
+        logger.debug("Registering worker")
+        worker_socket.send_multipart([b'', WORKER_READY, service_name])
+        
+        # Setup client with timeout
+        logger.debug("Setting up client socket")
+        client_context = zmq.Context()
+        client_socket = client_context.socket(zmq.DEALER)
+        client_socket.setsockopt(zmq.RCVTIMEO, 1000)  # 1 second timeout
+        client_socket.connect("tcp://localhost:5559")
+        
+        # Client sends request
+        request_data = {"action": "test"}
+        logger.debug("Client sending request")
+        client_socket.send_multipart([
+            b'',
+            service_name,
+            json.dumps(request_data).encode()
+        ])
+        
+        # Worker receives request
+        logger.debug("Worker waiting for request")
+        try:
+            worker_msg = worker_socket.recv_multipart()
+            logger.debug(f"Worker received message: {worker_msg}")
+            assert worker_msg[1] == REQUEST
+            client_id = worker_msg[2]
+            request = json.loads(worker_msg[3])
+            assert request == request_data
+        except zmq.error.Again:
+            pytest.fail("Timeout waiting for worker to receive request")
+        
+        # Worker sends reply
+        reply_data = {"result": "success"}
+        logger.debug("Worker sending reply")
+        worker_socket.send_multipart([
+            b'',
+            REPLY,
+            json.dumps(reply_data).encode(),
+            client_id
+        ])
+        
+        # Client receives reply
+        logger.debug("Client waiting for reply")
+        try:
+            client_msg = client_socket.recv_multipart()
+            logger.debug(f"Client received message: {client_msg}")
+            reply = json.loads(client_msg[2])
+            assert reply == reply_data
+        except zmq.error.Again:
+            pytest.fail("Timeout waiting for client to receive reply")
+        
+    finally:
+        logger.debug("Cleaning up test resources")
+        # Cleanup
+        if 'worker_socket' in locals():
+            worker_socket.close()
+        if 'client_socket' in locals():
+            client_socket.close()
+        if 'worker_context' in locals():
+            worker_context.term()
+        if 'client_context' in locals():
+            client_context.term()
+            
+        # Terminate broker process
+        logger.debug("Terminating broker process")
+        broker_process.terminate()
+        broker_process.join(timeout=1)
+        if broker_process.is_alive():
+            logger.warning("Broker didn't terminate, killing process")
+            broker_process.kill()
+            broker_process.join(timeout=1)
+
+if __name__ == '__main__':
+    pytest.main([__file__]) 

--- a/src/tests/test_type_validation.py
+++ b/src/tests/test_type_validation.py
@@ -90,7 +90,7 @@ def run_valid_type_test():
         }
         
         # Initialize system with restart to ensure clean state
-        ether.init(config=config, restart=True)
+        ether.tap(config=config, restart=True)
         time.sleep(1.0)  # Allow more time for setup
         
         # Create publisher and send messages
@@ -111,7 +111,7 @@ def run_invalid_type_test():
     """Test invalid type scenarios"""
     try:
         # Initialize system first
-        ether.init(restart=True)
+        ether.tap(restart=True)
         time.sleep(0.5)
         
         publisher = InvalidPublisher()
@@ -159,7 +159,7 @@ def run_type_mismatch_test():
         }
     }
     
-    ether.init(config=config, restart=True)
+    ether.tap(config=config, restart=True)
     time.sleep(0.5)
     
     publisher = MismatchPublisher()

--- a/src/tests/test_type_validation.py
+++ b/src/tests/test_type_validation.py
@@ -5,7 +5,7 @@ import logging
 from typing import List, Dict, Optional
 from pydantic import BaseModel
 from ether import ether, ether_pub, ether_sub
-from ether.utils import _get_logger
+from ether.utils import get_ether_logger
 
 # Test Models
 class ValidMessage(BaseModel):
@@ -21,7 +21,7 @@ class NestedMessage(BaseModel):
 class PublisherBase:
     def __init__(self, name=None):
         self.name = name or self.__class__.__name__
-        self._logger = _get_logger(self.__class__.__name__, instance_name=name)
+        self._logger = get_ether_logger(self.__class__.__name__, instance_name=name)
 
 # Test Classes
 class ValidPublisher:


### PR DESCRIPTION
Successfully added `EtherReqRepBroker` and `ether_save` and `ether_get` decorators along with some other nice stuff. There are working tests, in particular `test_ether_get.py` and `test_ether_save.py`. `test_ether_multiservice.py` is also good for ensuring we can scale this up.